### PR TITLE
Enable tests for int-to-double example

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: dartpad_examples
 
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.1.0-dev.7 <3.0.0'
 
 dev_dependencies:
   pedantic: ^1.0.0

--- a/test/dart_2_1/int_to_double_test.dart
+++ b/test/dart_2_1/int_to_double_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file.
 
-@Skip('Enable when 2.1.0-dev.7.0 is released - dart-lang/dartpad_examples#6')
-
 import 'package:dartpad_examples/dart_2_1/int_to_double.dart' as example;
 import 'package:test/test.dart';
 


### PR DESCRIPTION
Fixes dart-lang/dartpad_examples#6